### PR TITLE
Bounding rects

### DIFF
--- a/Texstyle/Texstyle.xcodeproj/project.pbxproj
+++ b/Texstyle/Texstyle.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		063FCBF52271FA02001C8962 /* TextStyle+Sugar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 063FCBF42271FA02001C8962 /* TextStyle+Sugar.swift */; };
 		063FCBF82271FA3B001C8962 /* String+Text.swift in Sources */ = {isa = PBXBuildFile; fileRef = 063FCBF72271FA3B001C8962 /* String+Text.swift */; };
 		063FCBFF2272094E001C8962 /* UIButton+Text.swift in Sources */ = {isa = PBXBuildFile; fileRef = 063FCBFE2272094E001C8962 /* UIButton+Text.swift */; };
+		06603ACC22CA11F9001F7644 /* BoundingRectOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06603ACB22CA11F9001F7644 /* BoundingRectOptions.swift */; };
 		06AE69022272DE8F00DD5D8F /* Texstyle.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 063FCBA12271E51C001C8962 /* Texstyle.framework */; };
 		06AE690A2272DE9C00DD5D8F /* TextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06AE69082272DE9C00DD5D8F /* TextTests.swift */; };
 		06AE690B2272DE9C00DD5D8F /* TextStyleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06AE69092272DE9C00DD5D8F /* TextStyleTests.swift */; };
@@ -49,6 +50,7 @@
 		063FCBF42271FA02001C8962 /* TextStyle+Sugar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TextStyle+Sugar.swift"; sourceTree = "<group>"; };
 		063FCBF72271FA3B001C8962 /* String+Text.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Text.swift"; sourceTree = "<group>"; };
 		063FCBFE2272094E001C8962 /* UIButton+Text.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+Text.swift"; sourceTree = "<group>"; };
+		06603ACB22CA11F9001F7644 /* BoundingRectOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoundingRectOptions.swift; sourceTree = "<group>"; };
 		06AE68FD2272DE8F00DD5D8F /* TexstyleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TexstyleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		06AE69012272DE8F00DD5D8F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		06AE69082272DE9C00DD5D8F /* TextTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextTests.swift; sourceTree = "<group>"; };
@@ -127,6 +129,7 @@
 				06C24D382273844600EDA46F /* ControlState+Random.swift */,
 				06C24D3422737B7700EDA46F /* TextStyle+Random.swift */,
 				06C24D3E227393F300EDA46F /* String+Random.swift */,
+				06603ACB22CA11F9001F7644 /* BoundingRectOptions.swift */,
 			);
 			path = TexstyleTests;
 			sourceTree = "<group>";
@@ -280,6 +283,7 @@
 			files = (
 				06AE690A2272DE9C00DD5D8F /* TextTests.swift in Sources */,
 				06C24D3F227393F300EDA46F /* String+Random.swift in Sources */,
+				06603ACC22CA11F9001F7644 /* BoundingRectOptions.swift in Sources */,
 				06C24D3B227384A800EDA46F /* UIButtonTests.swift in Sources */,
 				06C24D3522737B7700EDA46F /* TextStyle+Random.swift in Sources */,
 				06C24D392273844600EDA46F /* ControlState+Random.swift in Sources */,

--- a/Texstyle/Texstyle/Text.swift
+++ b/Texstyle/Texstyle/Text.swift
@@ -133,4 +133,24 @@ public final class Text {
         cachedAttributedStrings[state] = attributedString
         return attributedString
     }
+
+    ///Returns the bounding rectangle required to draw the string.
+    ///
+    /// - Parameters:
+    ///   - size: The width and height constraints to apply when computing the string’s bounding rectangle.
+    ///   - options: Additional drawing options to apply to the string during rendering.
+    ///   - context: A context object with information about how to adjust the font tracking and scaling information.
+    /// On return, the specified object contains information about the actual values used to render the string.
+    /// This parameter is nil by default.
+    ///   - state: The control state for attributes.
+    /// - Returns: A rectangle whose size component indicates the width and height required to draw the entire contents of the string.
+    public func boundingRect(with size: CGSize,
+                             options: NSStringDrawingOptions = [.usesLineFragmentOrigin, .usesFontLeading],
+                             context: NSStringDrawingContext? = nil,
+                             for state: ControlState = .normal) -> CGRect {
+        guard let attributedString = attributed(for: state) else {
+            return .zero
+        }
+        return attributedString.boundingRect(with: size, options: options, context: context)
+    }
 }

--- a/Texstyle/Texstyle/Text.swift
+++ b/Texstyle/Texstyle/Text.swift
@@ -143,7 +143,7 @@ public final class Text {
     /// On return, the specified object contains information about the actual values used to render the string.
     /// This parameter is nil by default.
     ///   - state: The control state for attributes.
-    /// - Returns: A rectangle whose size component indicates the width and height required to draw the entire contents of the string.
+    /// - Returns: A rectangle which size component indicates the width and height required to draw the entire contents of the string.
     public func boundingRect(with size: CGSize,
                              options: NSStringDrawingOptions = [.usesLineFragmentOrigin, .usesFontLeading],
                              context: NSStringDrawingContext? = nil,

--- a/Texstyle/TexstyleTests/BoundingRectOptions.swift
+++ b/Texstyle/TexstyleTests/BoundingRectOptions.swift
@@ -1,0 +1,24 @@
+//
+//  Copyright © 2019 Rosberry. All rights reserved.
+//
+
+@testable import Texstyle
+import UIKit
+
+struct BoundingRectOptions {
+
+    let size: CGSize
+    let options: NSStringDrawingOptions
+    let context: NSStringDrawingContext?
+    let state: ControlState
+
+    init(size: CGSize = CGSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude),
+         options: NSStringDrawingOptions = [.usesLineFragmentOrigin, .usesFontLeading],
+         context: NSStringDrawingContext? = nil,
+         state: ControlState = .normal) {
+        self.size = size
+        self.options = options
+        self.context = context
+        self.state = state
+    }
+}

--- a/Texstyle/TexstyleTests/TextTests.swift
+++ b/Texstyle/TexstyleTests/TextTests.swift
@@ -9,16 +9,20 @@ final class TextTests: XCTestCase {
 
     // MARK: - Values
 
-    private let value: String = .random(length: 6)
-    private let substring1: String = .random(length: 6)
-    private let substring2: String = .random(length: 6)
+    private lazy var value: String = .random(length: 6)
+    private lazy var substring1: String = .random(length: 6)
+    private lazy var substring2: String = .random(length: 6)
 
     // MARK: - Styles
 
-    private let style: TextStyle = .random
-    private let style1: TextStyle = .random
-    private let style2: TextStyle = .random
-    private let style3: TextStyle = .random
+    private lazy var style: TextStyle = .random
+    private lazy var style1: TextStyle = .random
+    private lazy var style2: TextStyle = .random
+    private lazy var style3: TextStyle = .random
+
+    // MARK: - Text
+
+    private lazy var text = Text(value: value, style: style1)
 
     // MARK: - Initialization
 
@@ -129,7 +133,6 @@ final class TextTests: XCTestCase {
     func testAddSubstyleForNormalState() {
         //Given
         let range = NSRange(location: 0, length: 2)
-        let text = Text(value: value, style: style1)
         //When
         text.add(style2, at: range)
         //Then
@@ -153,7 +156,6 @@ final class TextTests: XCTestCase {
         //Given
         let range2 = NSRange(location: 0, length: 2)
         let range3 = NSRange(location: 2, length: 2)
-        let text = Text(value: value, style: style1)
         //When
         text.add(style2, at: range2)
         text.add(style3, at: range3)
@@ -250,6 +252,65 @@ final class TextTests: XCTestCase {
         }
     }
 
+    // MARK: - Bounding rect
+
+    func testBoundingRectWithMaxSizeAndDefaultParameters() {
+        //Given
+        let options = BoundingRectOptions()
+        //When
+        let calculatedRect = text.boundingRect(with: options.size)
+        //Then
+        test(rect: calculatedRect, string: text.attributed, for: options)
+    }
+
+    func testBoundingRectWithConstrainedWidthAndDefaultParameters() {
+        //Given
+        let options = BoundingRectOptions(size: CGSize(width: 100, height: CGFloat.greatestFiniteMagnitude))
+        //When
+        let calculatedRect = text.boundingRect(with: options.size)
+        //Then
+        test(rect: calculatedRect, string: text.attributed, for: options)
+    }
+
+    func testBoundingRectWithConstrainedHeightAndDefaultParameters() {
+        //Given
+        let options = BoundingRectOptions(size: CGSize(width: CGFloat.greatestFiniteMagnitude, height: 5))
+        //When
+        let calculatedRect = text.boundingRect(with: options.size)
+        //Then
+        test(rect: calculatedRect, string: text.attributed, for: options)
+    }
+
+    func testBoundingRectWithCustomOptions() {
+        //Given
+        let options = BoundingRectOptions(options: [.usesFontLeading])
+        //When
+        let calculatedRect = text.boundingRect(with: options.size, options: options.options)
+        //Then
+        test(rect: calculatedRect, string: text.attributed, for: options)
+    }
+
+    func testBoundingRectWithCustomContext() {
+        //Given
+        let context = NSStringDrawingContext()
+        context.minimumScaleFactor = 0.5
+        let options = BoundingRectOptions(context: context)
+        //When
+        let calculatedRect = text.boundingRect(with: options.size, context: options.context)
+        //Then
+        test(rect: calculatedRect, string: text.attributed, for: options)
+    }
+
+    func testBoundingRectWithUnspecifiedState() {
+        //Given
+        let text = Text(value: value, styles: [.normal: style1])
+        let size = CGSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
+        //When
+        let calculatedRect1 = text.boundingRect(with: size, for: .disabled)
+        //Then
+        XCTAssertEqual(calculatedRect1, .zero, "Text returns wrong bounding rect for unspecified state")
+    }
+
     // MARK: - Private
 
     private func test(_ text: Text?, withValue value: String?, for state: ControlState, with style: TextStyle) {
@@ -341,6 +402,17 @@ final class TextTests: XCTestCase {
             return TexstyleTests.isEqual(type: NSNumber.self, a: a, b: b)
         }
         return false
+    }
+
+    private func test(rect: CGRect, string: NSAttributedString?, for options: BoundingRectOptions) {
+        //Given
+
+        //When
+        let calculatedRect = string?.boundingRect(with: options.size,
+                                                  options: options.options,
+                                                  context: options.context)
+        //Then
+        XCTAssertEqual(rect, calculatedRect, "Text returns wrong bounding rect for options: \(options)")
     }
 }
 


### PR DESCRIPTION
I added `Text` function for bounding rect calculation. There are default parameters, so for common case you should pass only constrained size. Please check related tests for more examples.
Related to https://github.com/rosberry/texstyle/issues/3