### PR TITLE
Support Require Only App-Extension-Safe API

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: macOS-latest
     strategy:
         matrix:
-          destination: ['platform=iOS Simulator,OS=13.3,name=iPhone 11']
+          destination: ['platform=iOS Simulator,OS=13.5,name=iPhone 11']
     steps:
       - name: Checkout
         uses: actions/checkout@master

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: macOS-latest
     strategy:
         matrix:
-          destination: ['platform=iOS Simulator,OS=13.3,name=iPhone 11', 'platform=tvOS Simulator,OS=13.3,name=Apple TV 4K']
+          destination: ['platform=iOS Simulator,OS=13.5,name=iPhone 11', 'platform=tvOS Simulator,OS=13.4,name=Apple TV 4K']
     steps:
       - name: Checkout
         uses: actions/checkout@master

--- a/Texstyle/Texstyle.xcodeproj/project.pbxproj
+++ b/Texstyle/Texstyle.xcodeproj/project.pbxproj
@@ -496,6 +496,7 @@
 		063FCBB62271E51C001C8962 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Manual;
@@ -529,6 +530,7 @@
 		063FCBB72271E51C001C8962 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Manual;


### PR DESCRIPTION
There is a limitation to [this](https://developer.apple.com/library/archive/documentation/General/Conceptual/ExtensibilityPG/ExtensionOverview.html#//apple_ref/doc/uid/TP40014214-CH2-SW6) for extension. And the compiler warns about this when you import the frameworks into Extension - “warning: binding with dylib is unsafe for use in application extensions”. By setting the flag APPLICATION_EXTENSION_API_ONLY = YES; We guarantee the extension that we do not use unavailable API.